### PR TITLE
Fix incorrect example YAML syntax in self-hosted docs

### DIFF
--- a/content/docs/hosting-instance.md
+++ b/content/docs/hosting-instance.md
@@ -80,10 +80,10 @@ services:
       # EMAIL_MAILGUN_API: key-yourkeygoeshere
       # EMAIL_MAILGUN_DOMAIN: yourdomain.com
 
-      # EMAIL_SMTP_HOST=smtp.yourdomain.com
-      # EMAIL_SMTP_PORT=587
-      # EMAIL_SMTP_USERNAME=user@yourdomain.com
-      # EMAIL_SMTP_PASSWORD=s0m3p4ssw0rd
+      # EMAIL_SMTP_HOST: smtp.yourdomain.com
+      # EMAIL_SMTP_PORT: 587
+      # EMAIL_SMTP_USERNAME: user@yourdomain.com
+      # EMAIL_SMTP_PASSWORD: s0m3p4ssw0rd
       
       ###
       # OPTIONAL


### PR DESCRIPTION
Uncommenting those lines and trying to run docker-compose leads to:

````
$ docker-compose pull
ERROR: yaml.scanner.ScannerError: while scanning a simple key
  in "./docker-compose.yml", line 47, column 7
could not find expected ':'
  in "./docker-compose.yml", line 48, column 7
````