### PR TITLE
Update Discord url

### DIFF
--- a/content/docs/configuring-oauth.mdx
+++ b/content/docs/configuring-oauth.mdx
@@ -107,16 +107,16 @@ This is only required for self-hosted Fider. Our Cloud service already has GitHu
 
 #### Discord
 
-1. Navigate to [https://discordapp.com/developers/applications](https://discordapp.com/developers/applications) and click on Create on aplication
+1. Navigate to [https://discord.com/developers/applications](https://discord.com/developers/applications) and click on Create on aplication
 2. Change your App Name and take note of the **Client ID** that is shown
 3. Under Client Secret, click on **click to reveal** and take note of **Client Secret** as well
 4. Fill Fider OAuth form as follows and then press Save
    - **Display Name:** Discord
    - **Client ID:** `use the Client ID given by Discord`
    - **Client Secret:** `use the Client Secret given by Discord`
-   - **Authorize URL:** https://discordapp.com/api/oauth2/authorize
-   - **Token URL:** https://discordapp.com/api/oauth2/token
-   - **Profile API URL:** https://discordapp.com/api/users/@me
+   - **Authorize URL:** https://discord.com/api/oauth2/authorize
+   - **Token URL:** https://discord.com/api/oauth2/token
+   - **Profile API URL:** https://discord.com/api/users/@me
    - **Scope:** identify email
    - **JSON Path ID:** id
    - **JSON Path Name:** username


### PR DESCRIPTION
Discord changed its domain to a year ago discord.com. discordapp still works, but it's better to do everything at once on discord.com.
![image](https://user-images.githubusercontent.com/54632865/124913903-60920d80-dff8-11eb-898e-dc775f49dfdf.png)
