### PR TITLE
API docs: fixed wrong param type and added authentication section

### DIFF
--- a/content/docs/api/comments.mdx
+++ b/content/docs/api/comments.mdx
@@ -105,6 +105,8 @@ GET <baseURL>/api/v1/posts/47/comments/68
 
 <h4 id="add-comment">Add a Comment</h4>
 
+- **Authentication:** Required
+
 ```
 POST /api/v1/posts/{number}/comments
 ```

--- a/content/docs/api/invitations.mdx
+++ b/content/docs/api/invitations.mdx
@@ -54,7 +54,7 @@ POST /api/v1/invitations/send
 | Name         | Type               | Description                                                                                                                                            |
 | ------------ | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `recipients` | `array of strings` | **Required.** The list of email addresses to send an invite.                                                                                           |
-| `subject`    | `number`           | **Required.** The subject of the email to be sent.                                                                                                     |
+| `subject`    | `string`           | **Required.** The subject of the email to be sent.                                                                                                     |
 | `message`    | `string`           | **Required.** The content of the email to be sent. The message must include the %invite% placeholder, which will be replaced a secure invitation link. |
 
 **Example**

--- a/content/docs/api/votes.mdx
+++ b/content/docs/api/votes.mdx
@@ -1,7 +1,7 @@
 <h3 id="votes">Votes</h3>
 
 - <a href="#add-vote">Vote on a Post</a>
-- <a href="#remove-vote">Remove Vote from on a Post</a>
+- <a href="#remove-vote">Remove Vote from a Post</a>
 - <a href="#list-post-votes">List Votes of a Post</a>
 
 <h4 id="add-vote">Vote on a Post</h4>
@@ -34,7 +34,7 @@ POST <baseURL>/api/v1/posts/47/votes
 {}
 ```
 
-<h4 id="remove-vote">Remove Vote from on a Post</h4>
+<h4 id="remove-vote">Remove Vote from a Post</h4>
 
 - **Authentication:** Required
 


### PR DESCRIPTION
Hello! This pull request fixes typos and missing sections I found while reading the API docs, to be exact:
- Send an invite: `subject` is typed as a `number` but should be a `string`
- Add a Comment: there's no `Authentication` section while the route requires it